### PR TITLE
ServerInboundHandler performance improvements

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -183,6 +183,7 @@ lazy val zioHttpBenchmarks = (project in file("zio-http-benchmarks"))
       "com.softwaremill.sttp.tapir" %% "tapir-http4s-server" % "1.5.1",
       "com.softwaremill.sttp.tapir" %% "tapir-json-circe"    % "1.5.1",
 //      "dev.zio"                     %% "zio-interop-cats"    % "3.3.0",
+      "org.apache.logging.log4j" % "log4j" % "2.20.0",
     ),
   )
   .dependsOn(zioHttp)

--- a/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/ServerInboundHandlerBenchmark.scala
+++ b/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/ServerInboundHandlerBenchmark.scala
@@ -38,9 +38,9 @@ class ServerInboundHandlerBenchmark {
     (for {
       _ <- zio.Console.printLine("Benchmarking start")
       _ <- Server.serve(http).fork
-      _ <- zio.Console.printLine("Server started on port 8080").
+      _ <- zio.Console.printLine("Server started on port 8080")
       client <- ZIO.service[Client]
-      _ <- (ZIO.foreachPar(0.until(PAR))(_ => client.get("/text")))  .repeat(MAX / PAR)
+      _ <- (ZIO.foreachPar((0 until PAR).toList)(_ => client.get("/text"))).repeatN(MAX / PAR)
     } yield ()).provide(Server.default, ZClient.default, zio.Scope.default)
 
   @Benchmark

--- a/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/ServerInboundHandlerBenchmark.scala
+++ b/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/ServerInboundHandlerBenchmark.scala
@@ -17,12 +17,7 @@ class ServerInboundHandlerBenchmark {
   private val res  = ZIO.succeed(Response.ok)
   private val http = Routes(Route.route(Method.GET / "text")(handler(res))).toHttpApp
 
-  @Benchmark
-  def benchmarkApp(): Unit = {
-    zio.Unsafe.unsafe(implicit u => zio.Runtime.default.unsafe.run(benchmarkZioParallel()))
-  }
-
-  def benchmarkZioParallel() =
+  def benchmarkZioParallel(): Task[Unit] =
     (for {
       _      <- Server.serve(http).fork
       client <- ZIO.service[Client]

--- a/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/ServerInboundHandlerBenchmark.scala
+++ b/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/ServerInboundHandlerBenchmark.scala
@@ -1,0 +1,52 @@
+package zhttp.benchmarks
+
+import zio.http.Client
+import org.openjdk.jmh.annotations._
+import zio._
+import zio.http._
+
+import java.util.concurrent.TimeUnit
+
+@State(org.openjdk.jmh.annotations.Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class ServerInboundHandlerBenchmark {
+
+  private val MAX  = 10000
+  private val PAR  = 10
+  private val res  = ZIO.succeed(Response.ok)
+  private val http = Routes(Route.route(Method.GET / "text")(handler(res))).toHttpApp
+
+
+  def benchmarkZio() =
+    (for {
+      _ <- zio.Console.printLine("Benchmarking start")
+      _ <- Server.serve(http).fork
+      _ <- zio.Console.printLine("Server started on port 8080")
+      client <- ZIO.service[Client]
+      _ <- client.get("/text").repeatN(MAX)
+    } yield ()).provide(Server.default, ZClient.default, zio.Scope.default)
+
+  @Benchmark
+  def benchmarkApp(): Unit = {
+    zio.Unsafe.unsafe(implicit u =>
+      zio.Runtime.default.unsafe.run(benchmarkZio())
+    )
+  }
+
+  def benchmarkZioParallel() =
+    (for {
+      _ <- zio.Console.printLine("Benchmarking start")
+      _ <- Server.serve(http).fork
+      _ <- zio.Console.printLine("Server started on port 8080").
+      client <- ZIO.service[Client]
+      _ <- (ZIO.foreachPar(0.until(PAR))(_ => client.get("/text")))  .repeat(MAX / PAR)
+    } yield ()).provide(Server.default, ZClient.default, zio.Scope.default)
+
+  @Benchmark
+  def benchmarkAppParallel(): Unit = {
+    zio.Unsafe.unsafe(implicit u =>
+      zio.Runtime.default.unsafe.run(benchmarkZioParallel())
+    )
+  }
+}


### PR DESCRIPTION
Cleanup & improve performance of server inbound handler (user6385 + fokot + jasper) from https://github.com/zio/zio-http/issues/2305
The idea is to minimise zio usage in `ServerInboundHandler` to make it faster.
We made `ServerInboundHandlerBenchmark` which can be run in sbt as
```
project  zioHttpBenchmarks
jmh:run .*ServerInboundHandlerBenchmark
```
Then you can add some printLine to method in `ServerInboundHandler` to see that it is called from benchmark. Optimise it and run benchmark again.
`Jasperz` on discord is also collaborator on this github project so I or he can add you if you want to contribute.